### PR TITLE
fix a bug where sometimes this.streamBlock result would be null but S…

### DIFF
--- a/lib/steem.js
+++ b/lib/steem.js
@@ -17,6 +17,10 @@ Steem.prototype.send = function(data, callback) {
 	w.onopen = function() {
 		w.send(JSON.stringify(data));
 	}
+
+	w.onerror = function(error){
+		callback(error, null)
+	}
 };
 
 
@@ -38,7 +42,7 @@ Steem.prototype.setPendingTransactionCallback = function(cb, callback) {
 		'method': 'set_pending_transaction_callback',
 		'params': [cb]
 	}, function(err, result) {
-		callback(err,result);
+		callback(err, result);
 	});
 };
 
@@ -657,13 +661,17 @@ Steem.prototype.streamBlockNumber = function(callback) {
 	};
 
 	w.onopen = function() {
-		setInterval(function () {
+		setInterval(function() {
 			w.send(JSON.stringify({
 				'id': 0,
 				'method': 'get_dynamic_global_properties',
 				'params': []
 			}));
-		}, 100);
+		}, 200);
+	}
+
+	w.onerror = function(error){
+		callback(error, null)
 	}
 };
 
@@ -677,32 +685,38 @@ Steem.prototype.streamBlock = function(callback) {
 
 	var self = this;
 	w.onopen = function() {
-		setInterval(function () {
+		setInterval(function() {
 			if (current != last) {
 				last = current;
-				self.getBlock(current, function(err,result) {
-					callback(null,result);
+				self.getBlock(current, function(err, result) {
+					callback(null, result);
 				});
 			}
-		}, 100);
+		}, 200);
+	}
+
+	w.onerror = function(error){
+		callback(error, null)
 	}
 };
 
 Steem.prototype.streamTransactions = function(callback) {
 	this.streamBlock(function(err, result) {
-		result.transactions.forEach(function (transaction) {
-			callback(null,transaction);
+		result.transactions.forEach(function(transaction) {
+			callback(null, transaction);
 		});
 	})
 };
 
 Steem.prototype.streamOperations = function(callback) {
 	this.streamBlock(function(err, result) {
-		result.transactions.forEach(function (transaction) {
-			transaction.operations.forEach(function (operation) {
-				callback(null,operation);
+		if(!!result){
+			result.transactions.forEach(function(transaction) {
+				transaction.operations.forEach(function(operation) {
+					callback(null, operation);
+				});
 			});
-		});
+		}	
 	})
 };
 


### PR DESCRIPTION
…teem.prototype.streamOperations would still try to loop over the transactions

increase interval time to query for new block to prevent Piston from throwing 503 errors

Signed-off-by: Kaptan Krayola <nhinrichs@gmail.com>