### PR TITLE
Lousy macro patch to #20

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -101,6 +101,7 @@ Steem.setSubscribeCallback = function(cb, clearFilter, callback) {
 		'method': 'set_subscribe_callback',
 		'params': [callback, clearFilter]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -113,6 +114,7 @@ Steem.setPendingTransactionCallback = function(cb, callback) {
 		'method': 'set_pending_transaction_callback',
 		'params': [cb]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -125,6 +127,7 @@ Steem.setBlockAppliedCallback = function(cb, callback) {
 		'method': 'set_block_applied_callback',
 		'params': [cb]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -136,6 +139,7 @@ Steem.cancelAllSubscriptions = function(callback) {
 		'id': iterator,
 		'method': 'cancel_all_subscriptions'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -151,6 +155,7 @@ Steem.getTrendingTags = function(afterTag, limit, callback) {
 		'method': 'get_trending_tags',
 		'params': [afterTag, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -163,6 +168,7 @@ Steem.getDiscussionsByTrending = function(query, callback) {
 		'method': 'get_discussions_by_trending',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -175,6 +181,7 @@ Steem.getDiscussionsByCreated = function(query, callback) {
 		'method': 'get_discussions_by_created',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -187,6 +194,7 @@ Steem.getDiscussionsByActive = function(query, callback) {
 		'method': 'get_discussions_by_active',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -199,6 +207,7 @@ Steem.getDiscussionsByCashout = function(query, callback) {
 		'method': 'get_discussions_by_cashout',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -211,6 +220,7 @@ Steem.getDiscussionsByPayout = function(query, callback) {
 		'method': 'get_discussions_by_payout',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -223,6 +233,7 @@ Steem.getDiscussionsByVotes = function(query, callback) {
 		'method': 'get_discussions_by_votes',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -235,6 +246,7 @@ Steem.getDiscussionsByChildren = function(query, callback) {
 		'method': 'get_discussions_by_children',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -247,6 +259,7 @@ Steem.getDiscussionsByHot = function(query, callback) {
 		'method': 'get_discussions_by_hot',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -259,6 +272,7 @@ Steem.getDiscussionsByFeed = function(query, callback) {
 		'method': 'get_discussions_by_feed',
 		'params': [query]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -273,6 +287,7 @@ Steem.getBlockHeader = function(blockNum, callback) {
 		'method': 'get_block_header',
 		'params': [blockNum]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -285,6 +300,7 @@ Steem.getBlock = function(blockNum, callback) {
 		'method': 'get_block',
 		'params': [blockNum]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -297,6 +313,7 @@ Steem.getState = function(path, callback) {
 		'method': 'get_state',
 		'params': [path]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -309,6 +326,7 @@ Steem.getTrendingCategories = function(after, limit, callback) {
 		'method': 'get_trending_categories',
 		'params': [after, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -321,6 +339,7 @@ Steem.getBestCategories = function(after, limit, callback) {
 		'method': 'get_best_categories',
 		'params': [after, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -333,6 +352,7 @@ Steem.getActiveCategories = function(after, limit, callback) {
 		'method': 'get_active_categories',
 		'params': [after, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -345,6 +365,7 @@ Steem.getRecentCategories = function(after, limit, callback) {
 		'method': 'get_recent_categories',
 		'params': [after, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -359,6 +380,7 @@ Steem.getConfig = function(callback) {
 		'id': iterator,
 		'method': 'get_config',
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -370,6 +392,7 @@ Steem.getDynamicGlobalProperties = function(callback) {
 		'id': iterator,
 		'method': 'get_dynamic_global_properties'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -381,6 +404,7 @@ Steem.getChainProperties = function(after, limit, callback) {
 		'id': iterator,
 		'method': 'get_chain_properties'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -392,6 +416,7 @@ Steem.getFeedHistory = function(callback) {
 		'id': iterator,
 		'method': 'get_feed_history'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -403,6 +428,7 @@ Steem.getCurrentMedianHistoryPrice = function(callback) {
 		'id': iterator,
 		'method': 'get_current_median_history_price'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -415,6 +441,7 @@ Steem.getWitnessSchedule = function(callback) {
 		'method': 'get_recent_categories',
 		'params': [after, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -426,6 +453,7 @@ Steem.getHardforkVersion = function(callback) {
 		'id': iterator,
 		'method': 'get_hardfork_version'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -437,6 +465,7 @@ Steem.getNextScheduledHardfork = function(callback) {
 		'id': iterator,
 		'method': 'get_next_scheduled_hardfork'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -452,6 +481,7 @@ Steem.getKeyReferences = function(key, callback) {
 		'method': 'get_key_references',
 		'params': [key]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -467,6 +497,7 @@ Steem.getAccounts = function(names, callback) {
 		'method': 'get_accounts',
 		'params': [names]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -479,6 +510,7 @@ Steem.getAccountReferences = function(accountId , callback) {
 		'method': 'get_account_references',
 		'params': [accountId]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -491,6 +523,7 @@ Steem.lookupAccountNames = function(accountNames, callback) {
 		'method': 'lookup_account_names',
 		'params': [accountNames]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -503,6 +536,7 @@ Steem.lookupAccounts = function(lowerBoundName, limit, callback) {
 		'method': 'lookup_accounts',
 		'params': [lowerBoundName, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -514,6 +548,7 @@ Steem.getAccountCount = function(callback) {
 		'id': iterator,
 		'method': 'get_account_count'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -526,6 +561,7 @@ Steem.getConversionRequests = function(accountName, callback) {
 		'method': 'get_conversion_requests',
 		'params': [accountName]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -538,6 +574,7 @@ Steem.getAccountHistory = function(account, from, limit, callback) {
 		'method': 'get_account_history',
 		'params': [account, from, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -550,6 +587,7 @@ Steem.getOwnerHistory = function(account, callback) {
 		'method': 'get_owner_history',
 		'params': [account]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -562,6 +600,7 @@ Steem.getRecoveryRequest = function(account, callback) {
 		'method': 'get_recovery_request',
 		'params': [account]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -577,6 +616,7 @@ Steem.getOrderBook = function(limit, callback) {
 		'method': 'getOrderBook',
 		'params': [limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -589,6 +629,7 @@ Steem.getOpenOrders = function(owner, callback) {
 		'method': 'get_open_orders',
 		'params': [owner]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -601,6 +642,7 @@ Steem.getLiquidityQueue = function(startAccount, limit, callback) {
 		'method': 'get_liquidity_queue',
 		'params': [startAccount, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -616,6 +658,7 @@ Steem.getTransactionHex = function(trx, callback) {
 		'method': 'get_transaction_hex',
 		'params': [trx]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -628,6 +671,7 @@ Steem.getTransaction = function(trxId, callback) {
 		'method': 'get_transaction',
 		'params': [trxId]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -640,6 +684,7 @@ Steem.getRequiredSignatures = function(trx, availableKeys, callback) {
 		'method': 'get_required_signatures',
 		'params': [trx, availableKeys]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -652,6 +697,7 @@ Steem.getPotentialSignatures = function(trx, callback) {
 		'method': 'get_potential_signatures',
 		'params': [trx]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -664,6 +710,7 @@ Steem.verifyAuthority = function(trx, callback) {
 		'method': 'verify_authority',
 		'params': [trx]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -676,6 +723,7 @@ Steem.verifyAccountAuthority = function(nameOrId, signers, callback) {
 		'method': 'verify_account_authority',
 		'params': [nameOrId, signers]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -691,6 +739,7 @@ Steem.getActiveVotes = function(author, permlink, callback) {
 		'method': 'get_active_votes',
 		'params': [author, permlink]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -703,6 +752,7 @@ Steem.getAccountVotes = function(voter, callback) {
 		'method': 'get_account_votes',
 		'params': [voter]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -718,6 +768,7 @@ Steem.getContent = function(author, permlink, callback) {
 		'method': 'get_content',
 		'params': [author, permlink]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -730,6 +781,7 @@ Steem.getContentReplies = function(parent, parentPermlink, callback) {
 		'method': 'get_content_replies',
 		'params': [parent, parentPermlink]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -742,6 +794,7 @@ Steem.getDiscussionsByAuthorBeforeDate = function(author, startPermlink, beforeD
 		'method': 'get_discussions_by_author_before_date',
 		'params': [author, startPermlink, beforeDate, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -754,6 +807,7 @@ Steem.getRepliesByLastUpdate = function(startAuthor, startPermlink, limit, callb
 		'method': 'get_replies_by_last_update',
 		'params': [startAuthor, startPermlink, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -769,6 +823,7 @@ Steem.getWitnesses = function(witnessIds, callback) {
 		'method': 'get_witnesses',
 		'params': [witnessIds]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -781,6 +836,7 @@ Steem.getWitnessByAccount = function(accountName, callback) {
 		'method': 'get_witness_by_account',
 		'params': [accountName]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -793,6 +849,7 @@ Steem.getWitnessesByVote = function(from, limit, callback) {
 		'method': 'get_witnesses_by_vote',
 		'params': [from, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -805,6 +862,7 @@ Steem.lookupWitnessAccounts = function(lowerBoundName, limit, callback) {
 		'method': 'lookup_witness_accounts',
 		'params': [lowerBoundName, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -816,6 +874,7 @@ Steem.getWitnessCount = function(callback) {
 		'id': iterator,
 		'method': 'get_witness_count'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -827,6 +886,7 @@ Steem.getActiveWitnesses = function(callback) {
 		'id': iterator,
 		'method': 'get_active_witnesses'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -838,6 +898,7 @@ Steem.getMinerQueue = function(callback) {
 		'id': iterator,
 		'method': 'get_miner_queue'
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -853,6 +914,7 @@ Steem.login = function(username, password, callback) {
 		'method': 'login',
 		'params': [username, password]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) {
 			this.getApiByName('network_broadcast_api', function() {});
 			callback(err, data.result);
@@ -868,6 +930,7 @@ Steem.getApiByName = function(apiName, callback) {
 		'method': 'get_api_by_name',
 		'params': [apiName]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) {
 			this.apiIds[apiName] = data.result;
 			callback(err, data.result);
@@ -886,6 +949,7 @@ Steem.getFollowers = function(following, startFollower, followType, limit, callb
 		'method': 'get_followers',
 		'params': [following, startFollower, followType, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -898,6 +962,7 @@ Steem.getFollowing = function(follower, startFollowing, followType, limit, callb
 		'method': 'get_following',
 		'params': [follower, startFollowing, followType, limit]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -913,6 +978,7 @@ Steem.broadcastTransaction = function(trx, callback) {
 		'method': 'broadcast_transaction',
 		'params': [trx]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -925,6 +991,7 @@ Steem.broadcastTransactionSynchronous = function(trx , callback) {
 		'method': 'broadcast_transaction_synchronous',
 		'params': [trx]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -937,6 +1004,7 @@ Steem.broadcastBlock = function(b, callback) {
 		'method': 'broadcast_block',
 		'params': [b]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };
@@ -949,6 +1017,7 @@ Steem.broadcastTransactionWithCallback = function(confirmationCallback, trx, cal
 		'method': 'broadcast_transaction_with_callback',
 		'params': [confirmationCallback, trx]
 	}, function(err, data) {
+		if (err) return callback(err);
 		if (iterator == data.id) callback(err, data.result);
 	});
 };


### PR DESCRIPTION
Fixes errors in `Steem.send` callbacks when `data` isn't
defined. Changes what happens when an error is thrown, since `data`
isn't always passed to API-level callbacks.