### PR TITLE
Initial implementation of API method codegen

### DIFF
--- a/lib/api-from-methods.js
+++ b/lib/api-from-methods.js
@@ -1,0 +1,60 @@
+var Steem = require('./api');
+var methods = require('./methods.json');
+
+var snakeCaseRe = /_([a-z])/g
+function camelCase(str) {
+  return str.replace(snakeCaseRe, function (_m, l) {
+    return l.toUpperCase();
+  });
+}
+
+exports = module.exports = methods.reduce(function (memo, method) {
+  var methodName = camelCase(method.method);
+
+  memo[methodName + 'With'] =
+    function Steem$specializedSendWith(options, callback) {
+      var params = method.params.map(function (param) {
+        return options[param];
+      });
+      var iterator = Steem.iterate();
+
+      return Steem.send(method.api, {
+        id: iterator,
+        method: method.method,
+        params: params,
+      }, function (err, data) {
+        if (err) return callback(err);
+        if (data && data.id === iterator) return callback(err, data.result);
+        // TODO - Do something here
+      });
+    };
+
+  memo[methodName] =
+    function Steem$specializedSend() {
+      var args = arguments;
+      var options = method.params.reduce(function (memo, param, i) {
+        memo[param] = args[i];
+        return memo;
+      }, {});
+      var callback = args[method.params.length];
+      memo[methodName + 'With'](options, callback);
+    };
+
+  return memo;
+}, {});
+
+/*
+
+console.log(exports);
+
+exports.getBlockWith({
+  blockNum: 1,
+}, function (err, operation) {
+  console.log(err, operation);
+});
+
+exports.getBlock(1, function (err, operation) {
+  console.log(err, operation);
+});
+
+ */

--- a/lib/methods.json
+++ b/lib/methods.json
@@ -1,0 +1,480 @@
+[
+  {
+    "api": "database_api",
+    "method": "set_subscribe_callback",
+    "params": [
+      "callback",
+      "clearFilter"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "set_pending_transaction_callback",
+    "params": [
+      "cb"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "set_block_applied_callback",
+    "params": [
+      "cb"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "cancel_all_subscriptions"
+  },
+  {
+    "api": "database_api",
+    "method": "get_trending_tags",
+    "params": [
+      "afterTag",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_trending",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_created",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_active",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_cashout",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_payout",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_votes",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_children",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_hot",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_feed",
+    "params": [
+      "query"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_block_header",
+    "params": [
+      "blockNum"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_block",
+    "params": [
+      "blockNum"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_state",
+    "params": [
+      "path"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_trending_categories",
+    "params": [
+      "after",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_best_categories",
+    "params": [
+      "after",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_active_categories",
+    "params": [
+      "after",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_recent_categories",
+    "params": [
+      "after",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_config"
+  },
+  {
+    "api": "database_api",
+    "method": "get_dynamic_global_properties"
+  },
+  {
+    "api": "database_api",
+    "method": "get_chain_properties"
+  },
+  {
+    "api": "database_api",
+    "method": "get_feed_history"
+  },
+  {
+    "api": "database_api",
+    "method": "get_current_median_history_price"
+  },
+  {
+    "api": "database_api",
+    "method": "get_recent_categories",
+    "params": [
+      "after",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_hardfork_version"
+  },
+  {
+    "api": "database_api",
+    "method": "get_next_scheduled_hardfork"
+  },
+  {
+    "api": "database_api",
+    "method": "get_key_references",
+    "params": [
+      "key"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_accounts",
+    "params": [
+      "names"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_account_references",
+    "params": [
+      "accountId"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "lookup_account_names",
+    "params": [
+      "accountNames"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "lookup_accounts",
+    "params": [
+      "lowerBoundName",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_account_count"
+  },
+  {
+    "api": "database_api",
+    "method": "get_conversion_requests",
+    "params": [
+      "accountName"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_account_history",
+    "params": [
+      "account",
+      "from",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_owner_history",
+    "params": [
+      "account"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_recovery_request",
+    "params": [
+      "account"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "getOrderBook",
+    "params": [
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_open_orders",
+    "params": [
+      "owner"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_liquidity_queue",
+    "params": [
+      "startAccount",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_transaction_hex",
+    "params": [
+      "trx"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_transaction",
+    "params": [
+      "trxId"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_required_signatures",
+    "params": [
+      "trx",
+      "availableKeys"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_potential_signatures",
+    "params": [
+      "trx"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "verify_authority",
+    "params": [
+      "trx"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "verify_account_authority",
+    "params": [
+      "nameOrId",
+      "signers"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_active_votes",
+    "params": [
+      "author",
+      "permlink"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_account_votes",
+    "params": [
+      "voter"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_content",
+    "params": [
+      "author",
+      "permlink"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_content_replies",
+    "params": [
+      "parent",
+      "parentPermlink"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_discussions_by_author_before_date",
+    "params": [
+      "author",
+      "startPermlink",
+      "beforeDate",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_replies_by_last_update",
+    "params": [
+      "startAuthor",
+      "startPermlink",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_witnesses",
+    "params": [
+      "witnessIds"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_witness_by_account",
+    "params": [
+      "accountName"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_witnesses_by_vote",
+    "params": [
+      "from",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "lookup_witness_accounts",
+    "params": [
+      "lowerBoundName",
+      "limit"
+    ]
+  },
+  {
+    "api": "database_api",
+    "method": "get_witness_count"
+  },
+  {
+    "api": "database_api",
+    "method": "get_active_witnesses"
+  },
+  {
+    "api": "database_api",
+    "method": "get_miner_queue"
+  },
+  {
+    "api": "login_api",
+    "method": "login",
+    "params": [
+      "username",
+      "password"
+    ]
+  },
+  {
+    "api": "login_api",
+    "method": "get_api_by_name",
+    "params": [
+      "apiName"
+    ]
+  },
+  {
+    "api": "follow_api",
+    "method": "get_followers",
+    "params": [
+      "following",
+      "startFollower",
+      "followType",
+      "limit"
+    ]
+  },
+  {
+    "api": "follow_api",
+    "method": "get_following",
+    "params": [
+      "follower",
+      "startFollowing",
+      "followType",
+      "limit"
+    ]
+  },
+  {
+    "api": "network_broadcast_api",
+    "method": "broadcast_transaction",
+    "params": [
+      "trx"
+    ]
+  },
+  {
+    "api": "network_broadcast_api",
+    "method": "broadcast_transaction_synchronous",
+    "params": [
+      "trx"
+    ]
+  },
+  {
+    "api": "network_broadcast_api",
+    "method": "broadcast_block",
+    "params": [
+      "b"
+    ]
+  },
+  {
+    "api": "network_broadcast_api",
+    "method": "broadcast_transaction_with_callback",
+    "params": [
+      "confirmationCallback",
+      "trx"
+    ]
+  }
+]


### PR DESCRIPTION
Doesn't mess with the exported API. Adds a `lib/api-from-methods` module
exporting all API methods that use the
`this.send(apiName, options, callback)` scheme.

The generated functions work as follows. For every method in
`methods.json`, two functions are generated:

- `camelCaseMethodWith`
- `camelCaseMethod`

The usages are:

```javascript
api.camelCaseMethodWith(options, callback);
```

And:
```javascript
api.camelCaseMethod(param1, param2, callback);
```

`options` currently holds parameters with their names generated from the
source `lib/api.js` variable names. For example:

```javascript
api.getBlockWith({
  blockNum: 1, // <- because `lib/api.js` called the variable `blockNum`
}, function (err, operation) {
  console.log(err, operation);
});

api.getBlock(1, function (err, operation) {
  console.log(err, operation);
});
```

Further improvements could be made to the method data and generated code. Namely:
- It'll require a `json-loader` or way to require `.json` files on
  browser bundlers
- It doesn't handle #22
- When there's no error but the `data.id` mismatches the iterator, the
  callback isn't called; this is a weird design decision

This closes #23.